### PR TITLE
increase swim-js version to support nat/docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/rjrodger/sneeze",
   "dependencies": {
     "lodash": "^4.0.0",
-    "swim": "0.2.0"
+    "swim": "0.3.0"
   },
   "devDependencies": {
     "code": "^2.1.0",


### PR DESCRIPTION
Need a new version to support this : https://github.com/mrhooray/swim-js/pull/5

which will allow us to containerize seneca-mesh services.

@rjrodger this is kind of urgent / a blocker.