### PR TITLE
Faster join in high join timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash": "4.5.0",
     "optioner": "0.8.0",
     "pad": "1.1.0",
-    "swim": "git://github.com/surfdude75/swim-js.git"
+    "swim": "0.6.0"
   },
   "devDependencies": {
     "code": "3.x.x",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash": "4.5.0",
     "optioner": "0.8.0",
     "pad": "1.1.0",
-    "swim": "0.3.2"
+    "swim": "git://github.com/surfdude75/swim-js.git"
   },
   "devDependencies": {
     "code": "3.x.x",


### PR DESCRIPTION
Service discovery could not work on high join timeouts.
PR was suggested and accepted in swim dependency.
Please upgrade dependency to latest version.